### PR TITLE
Add Tryolabs

### DIFF
--- a/data/companies.js
+++ b/data/companies.js
@@ -48,5 +48,15 @@ export default [
       allowFullRemote: true,
       hasPhysicalOffices: true
     }
+  },
+  {
+    picture: "https://tryolabs.com/images/layout/tryolabs-icon.0084317d.svg",
+    url: "https://tryolabs.com",
+    name: "Tryolabs",
+    description: "We build amazing products using Machine Learning & AI components",
+    meta: {
+      allowFullRemote: true,
+      hasPhysicalOffices: true
+    }
   }
 ];


### PR DESCRIPTION
This PR adds [Tryolabs](https://tryolabs.com) to the uruguayan remote work-promoting company listing.